### PR TITLE
Added POST functionality (details below)

### DIFF
--- a/lib/dashboard_api.rb
+++ b/lib/dashboard_api.rb
@@ -19,10 +19,20 @@ class DashboardAPI
   # @todo Eventually this will need to support POST, PUT and DELETE. It also
   #   needs to be a bit more resillient, instead of relying on HTTParty for exception
   #   handling
-  def make_api_call(endpoint_url=nil)
+  def make_api_call(endpoint_url, http_method, options_hash={})
     headers = {"X-Cisco-Meraki-API-Key" => @key}
-    options = {:headers => headers}
-    res = HTTParty.get("#{self.class.base_uri}/#{endpoint_url}", options)
-    return JSON.parse(res.body)
+    headers.merge!(options_hash[:headers]) if options_hash[:headers]
+
+    options = {:headers => headers, :body => options_hash[:body].to_json}
+    case http_method
+    when 'GET'
+      res = HTTParty.get("#{self.class.base_uri}/#{endpoint_url}", options)
+      return JSON.parse(res.body)
+    when 'POST'
+      res = HTTParty.post("#{self.class.base_uri}/#{endpoint_url}", options)
+      raise "Bad Request due to the following error(s): #{res['errors']}" if res['errors']
+      return res
+    end
+
   end
 end

--- a/lib/organizations.rb
+++ b/lib/organizations.rb
@@ -5,28 +5,28 @@ module Organizations
   # @param [String] org_id dashboard organization ID
   # @return [Hash] results contains the org  id and name of the given organization
   def get_organization(org_id)
-    self.make_api_call("/organizations/#{org_id}")
+    self.make_api_call("/organizations/#{org_id}", 'GET')
   end
 
   # Returns the current license state for a given organization
   # @param [String] org_id dashboard organization ID
   # @return [Hash] results contains the current license state information
   def get_license_state(org_id)
-    self.make_api_call("/organizations/#{org_id}/licenseState")
+    self.make_api_call("/organizations/#{org_id}/licenseState", 'GET')
   end
 
   # Returns the current inventory for an organization
   # @param [String] org_id dashboard organization ID
   # @return [Array] an array of hashes containg information on each individual device
   def get_inventory(org_id)
-    self.make_api_call("/organizations/#{org_id}/inventory")
+    self.make_api_call("/organizations/#{org_id}/inventory", 'GET')
   end
 
   # Returns the current SNMP status for an organization
   # @param [String] org_id dashboard organization ID
   # @return [Hash] a hash containing all SNMP configuration information for an organization
   def get_snmp_status(org_id)
-    self.make_api_call("/organizations/#{org_id}/snmp")
+    self.make_api_call("/organizations/#{org_id}/snmp", 'GET')
   end
 
   # Returns the configurations for an organizations 3rd party VPN peers
@@ -34,6 +34,6 @@ module Organizations
   # @return [Array] an arrry of hashes containing the configuration information
   #   for each 3rd party VPN peer
   def get_third_party_peers(org_id)
-    self.make_api_call("/organizations/#{org_id}/thirdPartyVPNPeers")
+    self.make_api_call("/organizations/#{org_id}/thirdPartyVPNPeers", 'GET')
   end
 end

--- a/test/test_dashboard_api.rb
+++ b/test/test_dashboard_api.rb
@@ -2,6 +2,7 @@ require 'minitest/autorun'
 require './lib/dashboard_api.rb'
 require 'minitest/reporters'
 require 'vcr'
+require 'json'
 Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new
 
 VCR.configure do |config|
@@ -23,5 +24,39 @@ class DashAPITest < Minitest::Test
 
   def test_api_key_is_a_string
     assert_kind_of String, @dapi.key
+  end
+
+  def test_it_can_get
+    VCR.use_cassette('it_can_get') do
+      endpoint_url = "/organizations/#{@org_id}"
+      http_method = 'GET'
+      res = @dapi.make_api_call(endpoint_url, http_method)
+
+      assert_equal @org_id.to_i, res['id']
+    end 
+  end
+
+  def test_it_can_post
+    VCR.use_cassette('it_can_post') do
+      endpoint_url = "/organizations/#{@org_id}/networks"
+      http_method = 'POST'
+      options_hash = {:headers => {"Content-Type" => 'application/json'}, :body =>{:name => 'test_network2', :type => 'wireless'}}
+
+      res = @dapi.make_api_call(endpoint_url, http_method, options_hash)
+
+      assert_equal 'Created', res.response.message
+    end
+  end
+
+  def test_it_asserts_when_a_bad_post
+    VCR.use_cassette('network_already_exists_post') do
+      assert_raises 'RuntimeError: Bad Request due to the following error(s): ["Validation failed: Name has already been taken"]' do
+        endpoint_url = "/organizations/#{@org_id}/networks"
+        http_method = 'POST'
+        options_hash = {:headers => {"Content-Type" => 'application/json'}, :body =>{:name => 'test_network2', :type => 'wireless'}}
+
+        res = @dapi.make_api_call(endpoint_url, http_method, options_hash)
+      end
+    end
   end
 end


### PR DESCRIPTION
**dashboard_api:**
Now contains support for POST functionality. The actual options that will be passed during the post, such as the network name and type when creating a new network are part of the 'body' section and automatically gets serialized to json.

The POST will also watch out for errors, such as a network already existing, and will raise an exception for this letting you know why it errored.

**test_dashboard_api:**
3 new tests. 1 to check basic functionality of the make_api_call for GET
1 to check the basic functionality of make_api_call for POST
1 to check the basic error handling of make_api_call for POST

**organizations.rb**
Since make_api_call now requries an HTTP_METHOD to be passed along side of it, all previous calls needed to be updated appropriately