### PR TITLE
removed redundant calls to putting options into options hash

### DIFF
--- a/lib/admins.rb
+++ b/lib/admins.rb
@@ -13,17 +13,17 @@ module Admins
   # @param [Hash] options option hash containing attributes for the new admin. Can contain:
   #   email, name, orgAccess, tags and networks. See the Meraki API Documentation for more details.
   def add_admin(org_id, options)
-    options = {:body => options}
+  #  
     self.make_api_call("/organizations/#{org_id}/admins", 'POST', options)
   end
- 
+
   # Update an administrator for a specific org
   # @param [String] org_id organization ID you want to update an administrator on
   # @param [String] admin_id ID of the admin you want to update
   # @param [Hash] options hash containing the attributes and values you want to update. Can contain:
   #   email, name, orgAccess, tags and networks. See the Meraki API Documentation for more details.
   def update_admin(org_id, admin_id, options)
-    options = {:body => options}
+#    
     self.make_api_call("/organizations/#{org_id}/admins/#{admin_id}", 'PUT', options)
   end
 

--- a/lib/dashboard-api.rb
+++ b/lib/dashboard-api.rb
@@ -44,9 +44,8 @@ class DashboardAPI
   #   handling
   def make_api_call(endpoint_url, http_method, options_hash={})
     headers = {"X-Cisco-Meraki-API-Key" => @key, 'Content-Type' => 'application/json'}
-    headers.merge!(options_hash[:headers]) if options_hash[:headers]
 
-    options = {:headers => headers, :body => options_hash[:body].to_json}
+    options = {:headers => headers, :body => options_hash.to_json}
     case http_method
     when 'GET'
       res = HTTParty.get("#{self.class.base_uri}/#{endpoint_url}", options)
@@ -60,7 +59,7 @@ class DashboardAPI
       begin
         return JSON.parse(res.body)
       rescue JSON::ParserError => e
-        return res.code 
+        return res.code
       rescue TypeError => e
         return res.code
       end

--- a/lib/devices.rb
+++ b/lib/devices.rb
@@ -33,7 +33,7 @@ module Devices
   # @return [Hash] a hash containing the devices new attribute set
   def update_device_attributes(network_id, device_serial, options)
     raise 'Options were not passed as a Hash' if !options.is_a?(Hash)
-    options = {:body => options}
+    
     self.make_api_call("/networks/#{network_id}/devices/#{device_serial}", 'PUT', options)
   end
 
@@ -43,7 +43,7 @@ module Devices
   # @return [Integer] code returns the HTTP code of the API call
   def claim_device_into_network(network_id, options)
     raise 'Options were not passed as a Hash' if !options.is_a?(Hash)
-    options = {:body => options}
+    
     self.make_api_call("/networks/#{network_id}/devices/claim", 'POST', options) 
   end
 

--- a/lib/networks.rb
+++ b/lib/networks.rb
@@ -23,7 +23,7 @@ module Networks
   # @return [Hash] a hash containing the updated network details
   def update_network(network_id, options)
     raise 'Options were not passed as a Hash' if !options.is_a?(Hash)
-    options = {:body => options}
+    
     self.make_api_call("/networks/#{network_id}",'PUT', options)
   end
 
@@ -36,7 +36,7 @@ module Networks
   # @return [Hash] a hash containing the new networks details
   def create_network(org_id, options)
     raise 'Options were not passed as a Hash' if !options.is_a?(Hash)
-    options = {:body => options}
+    
     self.make_api_call("/organizations/#{org_id}/networks", 'POST', options)
   end
 
@@ -65,7 +65,7 @@ module Networks
   def update_auto_vpn_settings(network_id, options)
     raise 'Options were not passed as a Hash' if !options.is_a?(Hash)
 
-    options = {:body => options}
+    
     res = self.make_api_call("/networks/#{network_id}/siteToSiteVpn", 'PUT', options)
   end
 
@@ -84,7 +84,7 @@ module Networks
   # @return [Integer] HTTP Code
   def bind_network_to_template(network_id, options)
     raise 'Options were not passed as a Hash' if !options.is_a?(Hash)
-    options = {:body => options}
+    
 
     self.make_api_call("/networks/#{network_id}/bind", 'POST', options)
   end
@@ -102,7 +102,7 @@ module Networks
   #   Meraki Dashboard API documentation for more information on these.
   def traffic_analysis(network_id, options)
     raise 'Options were not passed as a Hash' if !options.is_a?(Hash)
-    options = {:body => options}
+    
     self.make_api_call("/networks/#{network_id}/traffic", 'GET', options)
   end
 end

--- a/lib/organizations.rb
+++ b/lib/organizations.rb
@@ -38,7 +38,7 @@ module Organizations
   def update_snmp_settings(org_id, options)
     raise 'Options were not passed as a Hash' if !options.is_a?(Hash)
 
-    options = {:body => options}
+
     self.make_api_call("/organizations/#{org_id}/snmp", 'PUT', options)
   end
 
@@ -58,7 +58,6 @@ module Organizations
   def update_third_party_peers(org_id, options)
     raise 'Options were not passed as an Array' if !options.is_a?(Array)
 
-    options = {:body => options}
     self.make_api_call("/organizations/#{org_id}/thirdPartyVPNPeers", 'PUT', options)
   end
 
@@ -75,7 +74,6 @@ module Organizations
   def update_organization(org_id, options)
     raise 'Options were not passed as a Hash' if !options.is_a?(Hash)
 
-    options = {:body => options}
     self.make_api_call("/organizations/#{org_id}", 'PUT', options)
   end
 
@@ -85,7 +83,6 @@ module Organizations
   def create_organization(options)
     raise 'Options were not passed as a Hash' if !options.is_a?(Hash)
 
-    options = {:body => options}
     self.make_api_call("/organizations", 'POST', options)
   end
 
@@ -96,7 +93,6 @@ module Organizations
   def clone_organization(source_org_id, options)
     raise 'Options were not passed as a Hash' if !options.is_a?(Hash)
 
-    options = {:body => options}
     self.make_api_call("/organizations/#{source_org_id}/clone", 'POST', options)
   end
 
@@ -109,7 +105,6 @@ module Organizations
   def claim(org_id, options)
     raise 'Options were not passed as a Hash' if !options.is_a?(Hash)
 
-    options = {:body => options}
     self.make_api_call("/organizations/#{org_id}/claim", 'POST', options)
   end
 end

--- a/lib/phones.rb
+++ b/lib/phones.rb
@@ -15,7 +15,7 @@ module Phones
   # @return [Hash] returns the hash containing the contact attributes
   def add_phone_contact(network_id, options)
     raise 'Options were not passed as a Hash' if !options.is_a?(Hash)
-    options = {:body => options}
+    
     self.make_api_call("/networks/#{network_id}/phoneContacts", 'POST', options)
   end
 
@@ -26,7 +26,7 @@ module Phones
   # @return [Hash] returns the hash containing the contacts updated attributes
   def update_phone_contact(network_id, contact_id, options)
     raise 'Options were not passed as a Hash' if !options.is_a?(Hash)
-    options = {:body => options}
+    
     self.make_api_call("/networks/#{network_id}/phoneContacts/#{contact_id}", 'PUT', options)
   end
 

--- a/lib/saml.rb
+++ b/lib/saml.rb
@@ -14,7 +14,7 @@ module SAML
   #   Refer to the Meraki Dashboard API for more information on these tags
   # @return [Hash] returns the newly created SAML role
   def create_saml_role(org_id, options)
-    options = {:body => options}
+    
     self.make_api_call("/organizations/#{org_id}/samlRoles", 'POST', options)
   end
 
@@ -25,7 +25,7 @@ module SAML
   #   Refer to the Meraki Dashboard API for more information on these tags
   # @return [Hahs] returns the updated SAML role
   def update_saml_role(org_id, saml_id, options)
-    options = {:body => options}
+    
     self.make_api_call("/organizations/#{org_id}/samlRoles/#{saml_id}", 'PUT', options)
   end
 

--- a/lib/ssids.rb
+++ b/lib/ssids.rb
@@ -25,7 +25,7 @@ module SSIDs
   def update_single_ssid(network_id, ssid_number, options)
     raise 'Options were not passed as a Hash' if !options.is_a?(Hash)
     raise "Please provide a valid SSID number" unless (ssid_number.is_a?(Integer) && ssid_number <= 14)
-    options = {:body => options}
+    
 
     self.make_api_call("/networks/#{network_id}/ssids/#{ssid_number}", 'PUT', options)
   end

--- a/lib/switchports.rb
+++ b/lib/switchports.rb
@@ -26,7 +26,7 @@ module Switchports
   def update_switchport(device_serial, port_number, options)
     raise 'Options were not passed as a Hash' if !options.is_a?(Hash)
     raise 'Invalid switchport provided' unless port_number.is_a?(Integer)
-    options = {:body => options}
+    
     
     self.make_api_call("/devices/#{device_serial}/switchPorts/#{port_number}", 'PUT', options)
   end

--- a/lib/vlans.rb
+++ b/lib/vlans.rb
@@ -23,7 +23,7 @@ module VLANs
   # @return [Hash] the attributes of the newly created vlan
   def add_vlan(network_id, options)
     raise 'Options were not passed as a Hash' if !options.is_a?(Hash)
-    options = {:body => options}
+    
     self.make_api_call("/networks/#{network_id}/vlans", 'POST', options)
   end
 
@@ -35,7 +35,7 @@ module VLANs
   # @return [Hash] the updated attributes for the VLAN
   def update_vlan(network_id, vlan_id, options)
     raise 'Options were not passed as a Hash' if !options.is_a?(Hash)
-    options = {:body => options}
+    
     self.make_api_call("/networks/#{network_id}/vlans/#{vlan_id}", 'PUT', options)
   end
 

--- a/test/test_admins.rb
+++ b/test/test_admins.rb
@@ -8,38 +8,38 @@ class AdminsTest < Minitest::Test
     assert_kind_of Array, res
   end
 
-  # def test_it_can_create_admins
-  #   delete_admin
-  #   begin
-  #     # create a random email username
-  #     options = {:email => "delete-me#{rand(36**10).to_s(36)}@example.com", :name => 'delete me',
-  #                         :orgAccess => 'read-only'}
-  #     res = @dapi.add_admin(@org_id, options)
-  #   rescue => e
-  #     puts e
-  #     delete_admin if e.message.include?('is already registered')
-  #     retry
-  #   end
-  #
-  #   assert_kind_of Hash, res
-  #   assert_match /delete/, res['email']
-  # end
-  #
-  #
-  # def test_it_can_update_an_admin
-  #
-  #     options = {:name => 'updated admin'}
-  #     res = @dapi.update_admin(@org_id, @admin_id, options)
-  #
-  #     assert_kind_of Hash, res
-  #     assert_equal options[:name], res['name']
-  #   end
-  #
-  # def test_it_can_revoke_an_admin
-  #
-  #   res = @dapi.revoke_admin(@org_id, @admin_id)
-  #
-  #   assert_equal 204, res.code
-  # end
+  def test_it_can_create_admins
+    delete_admin
+    begin
+      # create a random email username
+      options = {:email => "delete-me#{rand(36**10).to_s(36)}@example.com", :name => 'delete me',
+                          :orgAccess => 'read-only'}
+      res = @dapi.add_admin(@org_id, options)
+    rescue => e
+      puts e
+      delete_admin if e.message.include?('is already registered')
+      retry
+    end
+
+    assert_kind_of Hash, res
+    assert_match /delete/, res['email']
+  end
+
+
+  def test_it_can_update_an_admin
+
+      options = {:name => 'updated admin'}
+      res = @dapi.update_admin(@org_id, @admin_id, options)
+
+      assert_kind_of Hash, res
+      assert_equal options[:name], res['name']
+    end
+
+  def test_it_can_revoke_an_admin
+
+    res = @dapi.revoke_admin(@org_id, @admin_id)
+
+    assert_equal 204, res.code
+  end
 
 end

--- a/test/test_dashboard_api.rb
+++ b/test/test_dashboard_api.rb
@@ -20,7 +20,7 @@ class DashAPITest < Minitest::Test
   def test_it_can_post
     endpoint_url = "/organizations/#{@org_id}/networks"
     http_method = 'POST'
-    options_hash = {:headers => {"Content-Type" => 'application/json'}, :body =>{:name => 'DELETE ME', :type => 'wireless'}}
+    options_hash = {:name => 'DELETE ME', :type => 'wireless'}
 
     res = @dapi.make_api_call(endpoint_url, http_method, options_hash)
 
@@ -31,7 +31,7 @@ class DashAPITest < Minitest::Test
     assert_raises 'RuntimeError: Bad Request due to the following error(s): ["Validation failed: Name has already been taken"]' do
       endpoint_url = "/organizations/#{@org_id}/networks"
       http_method = 'POST'
-      options_hash = {:headers => {"Content-Type" => 'application/json'}, :body =>{:name => 'DELETE ME', :type => 'appliance'}}
+      options_hash = {:name => 'DELETE ME', :type => 'appliance'}
 
       res = @dapi.make_api_call(endpoint_url, http_method, options_hash)
     end
@@ -47,7 +47,7 @@ class DashAPITest < Minitest::Test
     endpoint_url = "/networks/#{@test_network_id}"
     http_method = 'PUT'
 
-    options_hash = {:body => {:id => "#{@test_network_id}", :name => 'DELETE ME'}}
+    options_hash = {:id => "#{@test_network_id}", :name => 'DELETE ME'}
     res = @dapi.make_api_call(endpoint_url, http_method, options_hash)
 
     assert_equal @org_id, res['organizationId']
@@ -58,7 +58,7 @@ class DashAPITest < Minitest::Test
       endpoint_url = "/networks/11111"
       http_method = 'PUT'
 
-      options_hash = {:headers => {"Content-Type" => 'application/json'}, :body => {:name => 'test_network_renamed2'}}
+      options_hash = {:name => 'test_network_renamed2'}
       res = @dapi.make_api_call(endpoint_url, http_method, options_hash)
     end
   end


### PR DESCRIPTION
For some reason
```ruby
options = {:body => options}
```
existed on every function with options. I moved that directly to make_api call:

```ruby
  def make_api_call(endpoint_url, http_method, options_hash={})
    headers = {"X-Cisco-Meraki-API-Key" => @key, 'Content-Type' => 'application/json'}

    options = {:headers => headers, :body => options_hash.to_json}
```