### PR TITLE
Added parentheses around error checking on line 70 to process correctly

### DIFF
--- a/lib/dashboard-api.rb
+++ b/lib/dashboard-api.rb
@@ -67,7 +67,7 @@ class DashboardAPI
       res = HTTParty.put("#{self.class.base_uri}/#{endpoint_url}", options)
       # needs to check for is an array, because when you update a 3rd party VPN peer, it returns as an array
       # if you screw something up, it returns as a Hash, and will hit the normal if res['errors'
-      raise "Bad Request due to the following error(s): #{res['errors']}" if res['errors'] unless JSON.parse(res.body).is_a? Array
+      (raise "Bad Request due to the following error(s): #{res['errors']}" if res['errors']) unless JSON.parse(res.body).is_a? Array
       raise "404 returned. Are you sure you are using the proper IDs?" if res.code == 404
       return JSON.parse(res.body)
     when 'DELETE'


### PR DESCRIPTION
The "raise", "if", "unless" statement does not process correctly if the "raise" and "if" are not first evaluated together.  The parentheses force the "raise", "if" to evaluate and then be evaluated against the "unless" correctly.